### PR TITLE
Use the Login Flow from NC25 upwards

### DIFF
--- a/nextcloudmonitor.py
+++ b/nextcloudmonitor.py
@@ -27,7 +27,7 @@ class NextcloudMonitor:
     def update(self):
         try:
             response = requests.get(
-                self.api_url, auth=(self.user, self.password), verify=self.verify_ssl
+                self.api_url, auth=(self.user, self.password), verify=self.verify_ssl, headers={"OCS-APIRequest": "true"}
             )
             self.data = response.json()["ocs"]["data"]
         except Exception as error:


### PR DESCRIPTION
According to the documentation of Nextcloud 25:
https://docs.nextcloud.com/server/21/developer_manual/client_apis/LoginFlow/index.html?highlight=converting%20app%20passwords 
We need to announce "OCS-APIRequest": "true" in the header to be able to use App Passwords. 
This still works with  user passwords aswell.
Tested with local instance of NC24 and 25 with both user passwords and app passwords.
Without this fix app passwords will fail on at least Nextcloud 25.