### PR TITLE
add skip paramaters

### DIFF
--- a/nextcloudmonitor.py
+++ b/nextcloudmonitor.py
@@ -12,13 +12,23 @@ class NextcloudMonitor:
         user (str): Username of the Nextcloud user with access to the monitor api
         app_password (str): App password generated from Nextcloud security settings page
         verify_ssl (bool): Allow bypassing ssl verification, but verify by default
+        skip_update (bool): Omit server updates data (default true)
+        skip_apps (bool): Omit app updates data (default false)
     """
 
-    def __init__(self, nextcloud_url, user, app_password, verify_ssl=True):
+    def __init__(self, nextcloud_url, user, app_password, verify_ssl=True, skip_update=True, skip_apps=False):
         self.data = dict()
         self.api_url = (
             f"{nextcloud_url}/ocs/v2.php/apps/serverinfo/api/v1/info?format=json"
         )
+        if skip_update:
+            self.api_url += "&skipUpdate=true"
+        else:
+            self.api_url += "&skipUpdate=false"
+        if skip_apps:
+            self.api_url += "&skipApps=true"
+        else:
+            self.api_url += "&skipApps=false"
         self.user = user
         self.password = app_password
         self.verify_ssl = verify_ssl


### PR DESCRIPTION
This will add both paramaters `skipUpdate` and `skipApps` (_see the [api docs](https://github.com/nextcloud/serverinfo?tab=readme-ov-file#api)_). To avoid breaking changes, the defaults are set to the same as the api has.
- fixes #7