### PR TITLE
Add token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ pip install nextcloudmonitor
 
 ## QuickStart
 
+### Using an app password
 ```python
 >>> from nextcloudmonitor import NextcloudMonitor
 >>> ncm = NextcloudMonitor("https://your_nextcloud_url", "nextcloud_admin_username", "nextcloud_app_password")
@@ -20,9 +21,22 @@ pip install nextcloudmonitor
 ```
 
 Notes:
-
 - The user must be a user that has access to the nextcloud monitor api (generally an admin user)
 - The nextcloud app password should be generated from the nextcoud security settings page.
+
+### Using an access token
+```python
+>>> from nextcloudmonitor import NextcloudMonitor
+>>> ncm = NextcloudMonitor("https://your_nextcloud_url", "", "serverinfo_access_token")
+>>> ncm.data['nextcloud']['system']['version']
+'16.0.5.1'
+>>> ncm.data['activeUsers']['last24hours']
+1
+```
+
+Notes:
+ - The access token is a self-generated string set using `occ config:app:set serverinfo token --value your_access_token`
+ - The access token is currently limited to the serverinfo app
 
 ## Change Log
 

--- a/nextcloudmonitor.py
+++ b/nextcloudmonitor.py
@@ -9,8 +9,8 @@ class NextcloudMonitor:
 
     Attributes:
         nextcloud_url (str): Full https url to a nextcloud instance
-        user (str): Username of the Nextcloud user with access to the monitor api
-        app_password (str): App password generated from Nextcloud security settings page
+        user (str): Username of the Nextcloud user with access to the monitor api OR Empty to use app_password as token
+        app_password (str): App password generated from Nextcloud security settings page OR Serverinfo app access token set via occ
         verify_ssl (bool): Allow bypassing ssl verification, but verify by default
         skip_update (bool): Omit server updates data (default true)
         skip_apps (bool): Omit app updates data (default false)
@@ -29,16 +29,25 @@ class NextcloudMonitor:
             self.api_url += "&skipApps=true"
         else:
             self.api_url += "&skipApps=false"
-        self.user = user
-        self.password = app_password
+        if user:
+            self.user = user
+            self.password = app_password
+        else:
+            self.access_token = app_password
         self.verify_ssl = verify_ssl
         self.update()
 
     def update(self):
         try:
-            response = requests.get(
-                self.api_url, auth=(self.user, self.password), verify=self.verify_ssl
-            )
+            if hasattr(self, 'access_token'):
+                headers = { 'NC-Token': self.access_token }
+                response = requests.get(
+                    self.api_url, headers=headers, verify=self.verify_ssl
+                )
+            else:
+                response = requests.get(
+                    self.api_url, auth=(self.user, self.password), verify=self.verify_ssl
+                )
         except ConnectionError as error:
             raise NextcloudMonitorConnectionError(
                 f"Can not connect to nextcloud server: {error}"


### PR DESCRIPTION
When  the constructor attribute `user` is left empty, the `app_password` attribute is used as an access token.

This minimizes impact for existing implementations that may not use named constructor/function parameters.
Adding a new, optional attribute for an access_token would be cleaner but possibly break implementations.

I successfully tested these changes against my NC 32.0.2 instance using both authentication methods.

Readme adapted to show both authentication methods.
Versioning and changelog unchanged.

Fixes #12 